### PR TITLE
Request in plot.kobe

### DIFF
--- a/future2.1.r
+++ b/future2.1.r
@@ -4757,6 +4757,7 @@ fit.SR <- function(SRdata,SR="HS",method="L2",AR=1,TMB=FALSE,hessian=FALSE,w=rep
 
 plot.kobe <- function(vpares,Bmsy,Umsy,Blim=NULL,plot.history=FALSE,is.plot=FALSE,pickU="",pickB="",ylab.tmp="U/Umsy",xlab.tmp="SSB/SSBmsy",title.tmp=""){
     
+    if (is.null(vpares$wcaa)) vpares$wcaa <- vpares$input$dat$caa * vpares$input$dat$waa
     vpares$TC.MT <- as.numeric(colSums(vpares$wcaa))
     UBdata <- data.frame(years=as.numeric(colnames(vpares$baa)),
                          U=as.numeric(vpares$TC.MT)/as.numeric(colSums(vpares$baa,na.rm=T))/Umsy,


### PR DESCRIPTION
古いrvpaを使ってるとvparesにwcaaが入っていないことがあるので、plot.kobeに
if (is.null(vpares$wcaa)) vpares$wcaa <- vpares$input$dat$caa * vpares$input$dat$waa
を入れといていただけないでしょうか？大したことではないですが