### PR TITLE
fix but in plot_yield

### DIFF
--- a/utilities.r
+++ b/utilities.r
@@ -264,12 +264,17 @@ plot_yield <- function(MSY_obj,refs_base,
 
 
     }
-
+    
+    catch.past = unlist(colSums(past$input$dat$caa*past$input$dat$waa)/biomass.unit)
+    if (past$input$last.catch.zero) {
+      catch.past[length(catch.past)] = apply(future[[1]]$vwcaa[,-1],1,mean)[1]/biomass.unit
+    }
+    
     if(!is.null(past)){
         tmpdata <- tibble(
             year      =as.numeric(colnames(past$ssb)),
             ssb.past  =unlist(colSums(past$ssb))/biomass.unit,
-            catch.past=unlist(colSums(past$input$dat$caa*past$input$dat$waa)/biomass.unit)
+            catch.past=catch.past
         )
 
         g1 <- g1 +

--- a/utilities.r
+++ b/utilities.r
@@ -266,7 +266,7 @@ plot_yield <- function(MSY_obj,refs_base,
     }
     
     catch.past = unlist(colSums(past$input$dat$caa*past$input$dat$waa)/biomass.unit)
-    if (past$input$last.catch.zero) {
+    if (past$input$last.catch.zero && !is.null(future)) {
       catch.past[length(catch.past)] = apply(future[[1]]$vwcaa[,-1],1,mean)[1]/biomass.unit
     }
     


### PR DESCRIPTION
plot_yield関数において過去の推移もプロットする際、vpaの結果がlast.catch.zero=TRUEの場合、最後の年の漁獲量が0になってしまい、将来予測開始年とのずれが生じるので、その問題を解消するための修正をしてみました。
マサバ太平洋だけの問題でしたら、とりあえず保留でも大丈夫です。