### PR TITLE
fix out.AR option in fit.SR

### DIFF
--- a/future2.1.r
+++ b/future2.1.r
@@ -3251,10 +3251,11 @@ fit.SR <- function(SRdata,
   }
   
   if (AR==1 && out.AR) {
-    arres <- ar(resid,aic=FALSE,order.max=1)
+    arres <- ar(resid,aic=FALSE,order.max=1,demean=FALSE,method="mle")
     Res$pars[3] <- sqrt(arres$var.pred)
-    Res$pars[4] <- arres$ar
+    Res$pars[4] <- as.numeric(arres$ar)
     Res$resid2[2:length(Res$resid2)] <- arres$resid[-1]
+    Res$AIC.ar  <- ar(resid,order.max=1,demean=FALSE,method="mle")$aic
   }
   
   Res$loglik <- loglik <- -opt$value


### PR DESCRIPTION
外部からar関数を使って自己相関を推定する際に、exact likelihoodを使うようにし、切片を推定しないように変更しました。また、自己相関推定する場合としない場合のAICを$AIC.arで出力できるようにしました。